### PR TITLE
:test_tube: bump latest tested python to 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, MacOS, windows]
-        python-version: [3.7, "3.11"]
+        python-version: [3.7, "3.12"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
# Description

This is an enhancement

It increments the maximum tested python version to 3.12

# Pull request checklist

- [x] If features have changed, there's new documentation, and it has been checked: `nox -s docs -- serve`
- [x] If a bugfix, new tests are in `testing/`
- [x] Passes all CI/CD tests:
  - [x] Pre-commit linting passes: `nox -s lint`
  - [x] Package builds `nox -s build`
  - [x] Tests all pass: `nox -s tests`
