### PR TITLE
:memo: :bug: :hammer: change from myst_nb to myst_parser for docs to …

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ dependencies = [
 test = ["pytest >=6.2.5", "pytest-cov >=3.0.0", "coverage[toml] >=6.3.3"]
 docs = [
     "furo",
-    "myst-nb",
-    "sphinx",
+    "myst_parser>=0.13",
+    "sphinx>=7.0",
     "sphinx-autoapi",
     "sphinx-copybutton",
     "sphinx-design",


### PR DESCRIPTION
…fix a deprecation in sphinx-autoapi

# Description

This is a bugfix

It allows the docs to build

# Pull request checklist

- [x] If features have changed, there's new documentation, and it has been checked: `nox -s docs -- --serve`
- [x] If a bugfix, new tests are in `testing/`
- Passes all CI/CD tests:
  - [x] Pre-commit linting passes: `nox -s lint`
  - [ ] Package builds `nox -s build`
  - [x] Tests all pass: `nox -s tests`
