### PR TITLE
61 :bug: docs no longer building

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-    rust: "1.73"
+    rust: "1.70"
   apt_packages:
     - pandoc
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,8 +7,10 @@ sphinx:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
-    rust: "1.64"
+    python: "3.11"
+    rust: "1.73"
+  apt_packages:
+    - pandoc
 
 python:
   install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,22 +4,24 @@
 
 ## v0.3.2 (11/10/2023)
 
-
 **Critical fix:**
-* :bug: fix import error pitfall for maturin by @frank1010111 in https://github.com/frank1010111/pywaterflood/pull/62
+
+- :bug: fix import error pitfall for maturin by @frank1010111 in https://github.com/frank1010111/pywaterflood/pull/62
 
 **Python version update:**
-* :test_tube: bump latest tested python to 3.12 by @frank1010111 in https://github.com/frank1010111/pywaterflood/pull/60
+
+- :test_tube: bump latest tested python to 3.12 by @frank1010111 in https://github.com/frank1010111/pywaterflood/pull/60
 
 **Added tests:**
-* Add tests by @frank1010111 in https://github.com/frank1010111/pywaterflood/pull/56
-* Add tests by @frank1010111 in https://github.com/frank1010111/pywaterflood/pull/57
+
+- Add tests by @frank1010111 in https://github.com/frank1010111/pywaterflood/pull/56
+- Add tests by @frank1010111 in https://github.com/frank1010111/pywaterflood/pull/57
 
 **Dependency updates:**
-* build(deps): bump pypa/cibuildwheel from 2.15.0 to 2.16.0 by @dependabot in https://github.com/frank1010111/pywaterflood/pull/55
-* build(deps): bump pypa/cibuildwheel from 2.16.0 to 2.16.1 by @dependabot in https://github.com/frank1010111/pywaterflood/pull/59
-* :memo: :bug: :hammer: change from myst_nb to myst_parser for docs to … by @frank1010111 in https://github.com/frank1010111/pywaterflood/pull/63
 
+- build(deps): bump pypa/cibuildwheel from 2.15.0 to 2.16.0 by @dependabot in https://github.com/frank1010111/pywaterflood/pull/55
+- build(deps): bump pypa/cibuildwheel from 2.16.0 to 2.16.1 by @dependabot in https://github.com/frank1010111/pywaterflood/pull/59
+- :memo: :bug: :hammer: change from myst_nb to myst_parser for docs to … by @frank1010111 in https://github.com/frank1010111/pywaterflood/pull/63
 
 **Full Changelog**: https://github.com/frank1010111/pywaterflood/compare/v0.3.1...v0.3.2
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,7 @@ author = "Frank Male"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "nbsphinx",
     "myst_parser",
     "autoapi.extension",
     "sphinx.ext.mathjax",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,9 @@ dependencies = [
 test = ["pytest >=6.2.5", "pytest-cov >=3.0.0", "coverage[toml] >=6.3.3"]
 docs = [
     "furo",
+    "nbsphinx>=0.9",
     "myst_parser>=0.13",
+    "pandoc>=1.12",
     "sphinx>=7.0",
     "sphinx-autoapi",
     "sphinx-copybutton",


### PR DESCRIPTION
# Description

This is a documentation improvement

It really fixes the docs builds this time. Proven by [this build](https://pywaterflood.readthedocs.io/en/61-bug-docs-no-longer-building/)

## Pull request checklist

- [x] If features have changed, there's new documentation, and it has been checked: `nox -s docs -- --serve`
- [x] If a bugfix, new tests are in `testing/`
- Passes all CI/CD tests:
  - [x] Pre-commit linting passes: `nox -s lint`
  - [x] Package builds `nox -s build`
  - [x] Tests all pass: `nox -s tests`
