### PR TITLE
:hook: GHA: check wheel contents before publishing to TestPyPI or PyPI

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -63,7 +63,8 @@ jobs:
           path: dist
 
       - name: Check wheel contents
-        run: pipx run check-wheel-contents --package-omit='*abi3-musllinux*' dist/
+        # ignore abi3-musllinux false positives
+        run: pipx run check-wheel-contents --ignore=W009,W010 dist/
 
       - uses: pypa/gh-action-pypi-publish@v1.8.10
         with:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -62,6 +62,9 @@ jobs:
           name: artifact
           path: dist
 
+      - name: Check wheel contents
+        run: pipx run check-wheel-contents dist/
+
       - uses: pypa/gh-action-pypi-publish@v1.8.10
         with:
           # If you've already pushed this version to TestPyPI, don't fail the job
@@ -88,6 +91,9 @@ jobs:
           path: dist
 
       - run: pipx run twine check dist/*
+
+      - name: Check wheel contents
+        run: pipx run check-wheel-contents dist/
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.10

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -63,7 +63,7 @@ jobs:
           path: dist
 
       - name: Check wheel contents
-        run: pipx run check-wheel-contents dist/
+        run: pipx run check-wheel-contents --package-omit='*abi3-musllinux*' dist/
 
       - uses: pypa/gh-action-pypi-publish@v1.8.10
         with:


### PR DESCRIPTION
# Description

This is a bugfix

It enhances testing to make sure that the wheels generated are always sanity checked

## Pull request checklist

- [x] If features have changed, there's new documentation, and it has been checked: `nox -s docs -- --serve`
- [x] If a bugfix, new tests are in `testing/`
- Passes all CI/CD tests:
  - [x] Pre-commit linting passes: `nox -s lint`
  - [x] Package builds `nox -s build`
  - [ ] Tests all pass: `nox -s tests`
