### PR TITLE
Try getting codecov token to work again

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,6 @@ jobs:
         run: pipx run nox -s tests
       - name: "Upload coverage to Codecov"
         uses: codecov/codecov-action@v4
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Thing's cursed

# Description

This is a [choose one]
- bugfix

It is because codecov hates environmental variables and maybe wants me to use with: token again. A full 360.